### PR TITLE
docs: add AI instruction architecture decision log

### DIFF
--- a/AI-RULES.md
+++ b/AI-RULES.md
@@ -120,3 +120,8 @@ Pause and ask human before:
 
 Keep this file concise and operational.
 If project workflow changes, update this file first, then adapters.
+
+## 10) Decision log
+
+- 2026-02-14: adopted single-source AI instructions (`AI-RULES.md`) with thin adapter files (`AGENTS.md`, `CLAUDE.md`) to avoid rule drift across tools.
+- Rationale and context: see `README.md` -> "AI instruction architecture (decision record)".

--- a/README.md
+++ b/README.md
@@ -87,8 +87,36 @@ On the website side, Phase 2 will:
 We build section-by-section, banking value and committing regularly.
 
 If you’re working through the plan, the intended commit cadence is:
+
 - scaffold
 - tokens/base
 - header
 - hero
 - …and so on
+
+## AI instruction architecture (decision record)
+
+### Decision
+
+Use a single-source, tool-agnostic instruction system:
+
+- Canonical rules: `AI-RULES.md`
+- Thin adapters: `AGENTS.md` and `CLAUDE.md`
+
+### Why this decision was made
+
+- We use multiple AI coding tools and want one place to maintain operating rules.
+- Duplicating instructions across tool-specific files creates drift and ambiguity.
+- Thin adapters keep compatibility while preserving a single source of truth.
+
+### Operating rule
+
+- Update `AI-RULES.md` first when workflow/policy changes.
+- Keep `AGENTS.md` and `CLAUDE.md` minimal and referential.
+- If an adapter conflicts with `AI-RULES.md`, `AI-RULES.md` wins.
+
+### Related files
+
+- `AI-RULES.md`
+- `AGENTS.md`
+- `CLAUDE.md`


### PR DESCRIPTION
Documents the decision to use AI-RULES.md as single source of truth with thin AGENTS.md / CLAUDE.md adapters, and adds the decision record to README.md for future maintainer context.