### PR TITLE
[#95] fix(lead-capture): write fields that exist on Accounts

### DIFF
--- a/netlify/functions/lead-capture.js
+++ b/netlify/functions/lead-capture.js
@@ -81,7 +81,13 @@ exports.handler = async (event, context) => {
     const role = safeTrim(data.role, 200);
     const timelineRaw = safeTrim(data.timeline);
     const problem = safeTrim(data.problem || '', 500);
-    const interestRaw = safeTrim(data.interest || '', 200);
+    // Service interest is MULTI-select as of 2026-08-09 — the form may send a single
+    // string (current) or an array (once the redesign lands). Accept both so the
+    // function does not need to ship in lockstep with the form.
+    const interestRawList = (Array.isArray(data.interest) ? data.interest : [data.interest || ''])
+      .map((v) => safeTrim(v, 200))
+      .filter(Boolean);
+    const interestRaw = interestRawList.join(',');
     const source = safeTrim(data.source || '', 200);
     const consentGiven = data.consent_given === true;
     const consentTimestamp = safeTrim(data.consent_timestamp || new Date().toISOString());
@@ -120,7 +126,24 @@ exports.handler = async (event, context) => {
       'leadership-cohort': 'Open Cohort AI Bootcamp for Business Leaders',
       'just-exploring': 'Just exploring'
     };
-    const interest = interestLabels[interestRaw] || interestRaw || 'Not specified';
+    const interestList = interestRawList.map((key) => interestLabels[key] || key);
+    const interest = interestList.join(', ') || 'Not specified';
+
+    // Airtable single/multi-selects reject any value not already a choice (422
+    // UNKNOWN_FIELD_NAME's sibling, INVALID_MULTIPLE_CHOICE_OPTIONS). An unrecognised
+    // form value must therefore degrade to "not written" rather than fail the whole
+    // record — the lead matters more than the label. Notes keeps the raw value either
+    // way, so nothing is lost.
+    const TIMELINE_CHOICES = new Set(Object.values(timelineLabels).concat('Not specified'));
+    const INTEREST_CHOICES = new Set(Object.values(interestLabels).concat('Not specified'));
+    const timelineForAirtable = TIMELINE_CHOICES.has(timeline) ? timeline : null;
+    const interestForAirtable = interestList.filter((v) => INTEREST_CHOICES.has(v));
+    const unmappedSelects = [
+      TIMELINE_CHOICES.has(timeline) ? '' : `Timeline (unmapped): ${timeline}`,
+      interestList.length !== interestForAirtable.length
+        ? `Service interest (unmapped): ${interestList.filter((v) => !INTEREST_CHOICES.has(v)).join(', ')}`
+        : ''
+    ].filter(Boolean);
 
     // Build Slack Block Kit message
     const slackMessage = {
@@ -214,11 +237,12 @@ exports.handler = async (event, context) => {
           Company: company,
           Website: website,
           'Primary Contact Role': role,
-          Timeline: timeline,
+          ...(timelineForAirtable ? { Timeline: timelineForAirtable } : {}),
+          ...(interestForAirtable.length ? { 'Service Interest': interestForAirtable } : {}),
           Notes: [
-            interestRaw ? `Service interest: ${interest}` : '',
             source ? `Source detail: ${source}` : '',
-            problem ? `Trying to solve: ${problem}` : ''
+            problem ? `Trying to solve: ${problem}` : '',
+            ...unmappedSelects
           ].filter(Boolean).join('\n\n'),
           Source: 'Accelerator X Website',
           'Consent Given': consentGiven,

--- a/tests/functions/lead-capture.test.js
+++ b/tests/functions/lead-capture.test.js
@@ -192,8 +192,104 @@ test('service-interest slug is mapped to a readable label in Slack + Airtable No
       assert.ok(slackText.includes('no shared AI vocabulary'));
 
       const airtableCall = fetchStub.calls.find((c) => c.url.includes('api.airtable.com'));
-      assert.ok(airtableCall.body.fields.Notes.includes('Service interest: Leadership Team AI Activation'));
+      // Service interest is a real multipleSelects field as of 2026-08-09, not prose in
+      // Notes — that was the whole point of adding it. Notes keeps only the answers that
+      // have no structured home.
+      assert.deepEqual(airtableCall.body.fields['Service Interest'], ['Leadership Team AI Activation']);
+      assert.ok(!airtableCall.body.fields.Notes.includes('Service interest:'));
       assert.ok(airtableCall.body.fields.Notes.includes('Trying to solve: Our leadership team has no shared AI vocabulary'));
+    }
+  );
+});
+
+test('multiple service interests are written as an array (form may send string or array)', async () => {
+  await withEnv(
+    {
+      SLACK_WEBHOOK_URL: 'https://hooks.slack.test/lead',
+      AIRTABLE_TOKEN: 'tok',
+      AIRTABLE_BASE_ID: 'appTest',
+      AIRTABLE_TABLE: 'Accounts',
+    },
+    async (mod) => {
+      const fetchStub = makeFetchStub([
+        { match: 'hooks.slack.test', status: 200 },
+        { match: 'api.airtable.com', status: 200 },
+      ]);
+      global.fetch = fetchStub;
+
+      const res = await mod.handler(
+        makeEvent({ ...VALID_FIELDS, interest: ['company-enablement', 'leadership-activation'] })
+      );
+      assert.equal(res.statusCode, 200);
+
+      const airtableCall = fetchStub.calls.find((c) => c.url.includes('api.airtable.com'));
+      assert.deepEqual(airtableCall.body.fields['Service Interest'], [
+        'Company Enablement',
+        'Leadership Team AI Activation',
+      ]);
+
+      const slackText = JSON.stringify(fetchStub.calls.find((c) => c.url.includes('hooks.slack.test')).body);
+      assert.ok(slackText.includes('Company Enablement'));
+      assert.ok(slackText.includes('Leadership Team AI Activation'));
+    }
+  );
+});
+
+test('an unmapped select value degrades to Notes rather than 422-ing the whole record', async () => {
+  await withEnv(
+    {
+      SLACK_WEBHOOK_URL: 'https://hooks.slack.test/lead',
+      AIRTABLE_TOKEN: 'tok',
+      AIRTABLE_BASE_ID: 'appTest',
+      AIRTABLE_TABLE: 'Accounts',
+    },
+    async (mod) => {
+      const fetchStub = makeFetchStub([
+        { match: 'hooks.slack.test', status: 200 },
+        { match: 'api.airtable.com', status: 200 },
+      ]);
+      global.fetch = fetchStub;
+
+      // Airtable rejects any select value that is not already a choice. A form option
+      // added without adding the Airtable choice must cost us the label, never the lead.
+      const res = await mod.handler(
+        makeEvent({ ...VALID_FIELDS, interest: 'some-new-offering-nobody-added', timeline: 'next-decade' })
+      );
+      assert.equal(res.statusCode, 200);
+
+      const fields = fetchStub.calls.find((c) => c.url.includes('api.airtable.com')).body.fields;
+      assert.ok(!('Service Interest' in fields), 'unmapped interest must be omitted, not sent');
+      assert.ok(!('Timeline' in fields), 'unmapped timeline must be omitted, not sent');
+      assert.ok(fields.Notes.includes('Service interest (unmapped): some-new-offering-nobody-added'));
+      assert.ok(fields.Notes.includes('Timeline (unmapped): next-decade'));
+      assert.equal(fields['Primary Contact Name'], VALID_FIELDS.name, 'the lead itself must still be written');
+    }
+  );
+});
+
+test('consent is written as structured fields — the GDPR record, not prose', async () => {
+  await withEnv(
+    {
+      SLACK_WEBHOOK_URL: 'https://hooks.slack.test/lead',
+      AIRTABLE_TOKEN: 'tok',
+      AIRTABLE_BASE_ID: 'appTest',
+      AIRTABLE_TABLE: 'Accounts',
+    },
+    async (mod) => {
+      const fetchStub = makeFetchStub([
+        { match: 'hooks.slack.test', status: 200 },
+        { match: 'api.airtable.com', status: 200 },
+      ]);
+      global.fetch = fetchStub;
+
+      await mod.handler(
+        makeEvent({ ...VALID_FIELDS, consent_given: true, consent_timestamp: '2026-08-09T20:25:50.924Z' })
+      );
+
+      const fields = fetchStub.calls.find((c) => c.url.includes('api.airtable.com')).body.fields;
+      assert.equal(fields['Consent Given'], true);
+      assert.equal(fields['Consent Timestamp'], '2026-08-09T20:25:50.924Z');
+      assert.equal(fields['Primary Contact Role'], VALID_FIELDS.role);
     }
   );
 });


### PR DESCRIPTION
Closes #95

## The bug

A live test submission tonight posted to Slack, then failed its Airtable write with `422 UNKNOWN_FIELD_NAME: "Primary Contact Role"`.

Not a credential problem — a bad token returns 401/403. The function was writing **four** fields the `Accounts` table doesn't have: `Primary Contact Role`, `Timeline`, `Consent Given`, `Consent Timestamp`. Airtable names only the first unknown field per request, so this presents as one missing field and would have taken four live submissions to fully uncover.

Fallout from the ax-agent-hub#941 repoint: the function moved from the archived `Prospects` table to `Accounts`, and nothing checked the field set against the new table.

**Blast radius: every lead through accelerator-x.ai since that repoint reached Slack but never reached the CRM** — consent record included. The function's `GNG-1 path degraded` alert was firing correctly; the degradation was real.

## Airtable changes (already applied, additive)

Five fields added to `Accounts`, each carrying an in-schema description of its writer and why it exists:

| Field | Type |
|---|---|
| Primary Contact Role | singleLineText |
| Timeline | singleSelect |
| Service Interest | **multipleSelects** |
| Consent Given | checkbox |
| Consent Timestamp | dateTime (ISO, UTC) |

`Service Interest` is multi by design (Andy, 2026-08-09) — people want more than one. It also fixes a second problem found alongside: service interest, source detail and "trying to solve" were only ever written as prose inside `Notes`, so none of them were filterable.

## Function changes

- `Service Interest` and `Timeline` are now structured fields. `Notes` keeps only the answers with no structured home.
- `data.interest` accepts **a string or an array**, so this doesn't have to ship in lockstep with the form's multi-select redesign.
- **Unmapped select values degrade instead of failing.** Airtable rejects any select value that isn't already a choice, so adding a form option without adding the Airtable choice would 422 the whole record. Now the label is dropped, the raw value goes to `Notes`, and the lead is still written.

  That last one is the part worth reviewing: this bug cost real leads, and the obvious fix (write the new fields) would have left the same trapdoor open one option-rename later. Losing a label is acceptable; losing a lead is not.

## Verification

- `npm test`: **36/36**, including three new cases — the array path, the unmapped-value degradation, and consent written as structured fields.
- `npm run check`: all 10 standards checks pass.
- Still needs a **live submission** to confirm end to end; the mocked fetch returns 200 regardless of payload, which is exactly how the 2026-07-14 `Source` mismatch got through this suite before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)