### PR TITLE
docs(dns): record the newsletter reply-to fix

### DIFF
--- a/docs/tech-architecture/dns-hosting.md
+++ b/docs/tech-architecture/dns-hosting.md
@@ -93,6 +93,7 @@ If HTTPS stops working: go to Netlify → Domain management → HTTPS → **"Ren
 - **Sender address:** `newsletter@mail.accelerator-x.ai`
 - Authentication: SPF via Brevo, DKIM via `brevo1/2._domainkey.mail` CNAMEs, DMARC at `_dmarc.mail`
 - Signup flow: form → `/.netlify/functions/newsletter-subscribe` → Brevo API direct (bypasses Netlify Forms)
+- **Reply-To: `info@accelerator-x.ai`.** `mail.accelerator-x.ai` has no MX/A record — it's a send-only subdomain, so replies to the bare sender address bounce. The welcome-email automation (list #9 → contact added) has Reply-To set to `info@accelerator-x.ai` (a real Google Workspace inbox) so the "just reply" copy actually works. Fixed and verified live 2026-08-10 (accelerator-x-website#103); same pattern as `reports@mail.accelerator-x.ai` in ax-agent-hub#978.
 
 ---
 


### PR DESCRIPTION
## What

Documents the fix Andy already made and verified live: the Brevo newsletter welcome-email automation now has Reply-To set to `info@accelerator-x.ai`, so replying to the welcome email no longer bounces.

## Why

`mail.accelerator-x.ai` (the newsletter's From domain) has no MX/A record — it can only send, never receive — so the welcome email's "just reply, we read everything" copy was bouncing every reply. Same failure pattern already hit `reports@mail.accelerator-x.ai` and was fixed in ax-agent-hub#978 with the identical remedy (Reply-To override to a real inbox, From address unchanged).

## Verified

Andy tested live: signed up, replied, confirmed no bounce.

Closes #103
